### PR TITLE
Remove taint checking (ruby 3.2.0 compat)

### DIFF
--- a/lib/anystyle/data/setup.rb
+++ b/lib/anystyle/data/setup.rb
@@ -1,6 +1,6 @@
 module AnyStyle
   module Data
-    ROOT = File.expand_path('..', __FILE__).untaint
+    ROOT = File.expand_path('..', __FILE__)
 
     def self.setup
       Dictionary.defaults[:source] = File.join(ROOT, 'dict.txt.gz')


### PR DESCRIPTION
This change removes taint checking, which has been deprecated since Ruby 2.7 and has no effect.

Ruby 3.2.0 completely removes taint support, so this gem currently fails to compile under that Ruby version.

I don't think this should have any negative consequences for older Ruby versions.

See this thread for more info and links to similar gems with c extensions having taint checking
removed: https://bugs.ruby-lang.org/issues/16131#note-24

_This change accompanies the PR made to `wapiti` in https://github.com/inukshuk/wapiti-ruby/pull/9 and is required to be able to make the `anystyle` and `anystyle-cli` gems compatible with the latest Ruby version. PRs to them coming up after this is released._